### PR TITLE
Use new configuration options to es2015 preset

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,7 +7,7 @@ import * as path from 'path'
  */
 export = function babel({ options = {
     plugins: ['transform-decorators-legacy'],
-    presets: ['es2015-loose-native-modules', 'stage-1'],
+    presets: [['es2015', {loose: true, modules: false}], 'stage-1'],
     cacheDirectory: true,
   }, exclude = null } = {}) {
   return function babel(this: WebpackConfig): WebpackConfig {


### PR DESCRIPTION
The various derivative es2015 presets have been deprecated in favor of configuration options to the main es2015 preset.

Closes #3
